### PR TITLE
docs: add details on how to be elected as core contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ Core collaborators of the NodeSecure project.
   </tr>
 </table>
 
+<details>
+<summary>How to be elected core contributor?</summary>
+
+These are contributors who have **proven** their importance and impact through **multiple contributions** to one or more projects of the organisation.
+
+Contributing is not **only about coding**, it can also be participating in the **life** of the project which is just as important e.g. discord, meetings, branding, etc. Developers who are champions or maintainers of at least one project have a high probability to be elected to the core team.
+
+</details>
+
 ---
 
 Contributors on one and/or many open-source projects that touch the NodeSecure project.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Core collaborators of the NodeSecure project.
 
 These are contributors who have **proven** their importance and impact through **multiple contributions** to one or more projects of the organization.
 
-Contributing is not **only about coding**, it can also be participating in the **life** of the project which is just as important e.g. discord, meetings, branding, etc. Developers who are champions or maintainers of at least one project have a high probability to be elected to the core team.
+Contributing is not **only about coding**, but it can also be participating in the **life** of the project, which is just as important e.g. discord, meetings, branding, etc. Developers who are champions or maintainers of at least one project have a high probability of being elected to the core team.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Core collaborators of the NodeSecure project.
 <details>
 <summary>How to be elected core contributor?</summary>
 
-These are contributors who have **proven** their importance and impact through **multiple contributions** to one or more projects of the organisation.
+These are contributors who have **proven** their importance and impact through **multiple contributions** to one or more projects of the organization.
 
 Contributing is not **only about coding**, it can also be participating in the **life** of the project which is just as important e.g. discord, meetings, branding, etc. Developers who are champions or maintainers of at least one project have a high probability to be elected to the core team.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Core collaborators of the NodeSecure project.
 
 These are contributors who have **proven** their importance and impact through **multiple contributions** to one or more projects of the organization.
 
-Contributing is not **only about coding**, but it can also be participating in the **life** of the project, which is just as important e.g. discord, meetings, branding, etc. Developers who are champions or maintainers of at least one project have a high probability of being elected to the core team.
+Contributing is not **only about coding**, but it can also be participating in the **life** of the project, which is just as important e.g. discord, meetings, branding, etc. Developers who are [champions](https://github.com/NodeSecure/rfcs#champion) or maintainers of at least one project have a high probability of being elected to the core team.
 
 </details>
 


### PR DESCRIPTION
Add a details section to describe on what someone need to achieve to be elected as core contributor.