### PR TITLE
fix: typo in pipeline

### DIFF
--- a/.github/workflows/ossf-scorecard-reporting.yml
+++ b/.github/workflows/ossf-scorecard-reporting.yml
@@ -33,4 +33,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           max-request-in-parallel: 10
           discovery-enabled: true
-          discovery-orgs: 'nodesecure'
+          discovery-orgs: 'NodeSecure'


### PR DESCRIPTION
### Main changes

As discussed in https://github.com/NodeSecure/Governance/issues/21#issuecomment-1474770986, this will fix the typo in the org name.

### Context

Close https://github.com/NodeSecure/Governance/issues/21